### PR TITLE
Add travis integration and badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ script: bundle exec rspec
 # travis encrypt SONAR_API_URL=https://sonar.labs.rapid7.com -r rapid7/sonar-client
 secure: "hEjrs5xTiPpcyuxSjhBhme69sZlMP90kdyrAiHb8uc0ZGuYJ2JDgw6uk+iX6AWRQyTVnGSPi6mfow6n5pTZgX+NTC+L3SziW3Gt3TRGMqLd6lA/KbS0t0rd8Htupn8Rin4Z0+0Z9qayfX0b9xFmwTFLsNVs1Ed4mspPh0q9CLuI="
 # travis encrypt SONAR_EMAIL=<your email> -r rapid7/sonar-client
-secure: "XXX"
+secure: "QafEWWOK4poi7SHkkdJy+NhxIyaQ3luE60ktfnu+LlbtVhiHGdFfwQcNQxeNOgN2vWkldI7La9o4tL6V2eKc0K6EeuJJFgt1HEf9dSghn+Yy1Szm0b5T3dEnJyaqAw4buAV9qZSgmYrZJ9zNiUH/Tbhfsbk552WkCxVysImxQi0="
 # travis encrypt SONAR_TOKEN=<your token> -r rapid7/sonar-client
-secure: "XXX"
+secure: "cpaV274XRA97fQwZCsJNIKSmjGZ/ccJkyz7bvKcjuI3sIQGyIwJBNgz6Yn9QlrVrFliiVoVSBkAaZaUJVE2a8t2CzgtxqOfpWhkyb63KEig35eFEHw1qeXDTlIiIZAIJ0k5v4hi/+KcvFmEJpIMKlrSCn/CjNmVRhkT0LTdRCI0="

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,9 @@ before_install:
 before_script:
   - bundle exec rake --version
 script: bundle exec rspec
+# travis encrypt SONAR_API_URL=https://sonar.labs.rapid7.com -r rapid7/sonar-client
+secure: "hEjrs5xTiPpcyuxSjhBhme69sZlMP90kdyrAiHb8uc0ZGuYJ2JDgw6uk+iX6AWRQyTVnGSPi6mfow6n5pTZgX+NTC+L3SziW3Gt3TRGMqLd6lA/KbS0t0rd8Htupn8Rin4Z0+0Z9qayfX0b9xFmwTFLsNVs1Ed4mspPh0q9CLuI="
+# travis encrypt SONAR_EMAIL=<your email> -r rapid7/sonar-client
+secure: "XXX"
+# travis encrypt SONAR_TOKEN=<your token> -r rapid7/sonar-client
+secure: "XXX"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+sudo: false
+cache: bundler
+rvm:
+  - 2.1.5
+  - jruby
+before_install:
+  - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
+  - rake --version
+before_script:
+  - bundle exec rake --version
+script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ sonar-client
 
 Ruby API Wrapper and CLI for [Sonar](https://sonar.labs.rapid7.com)
 
+[![Gem Version](https://badge.fury.io/rb/sonar-client.svg)](http://badge.fury.io/rb/sonar-client)
+[![Build Status](https://travis-ci.org/rapid7/sonar-client.svg?branch=master)](https://travis-ci.org/rapid7/sonar-client)
+
 ## Installation
 
 Install the gem by running


### PR DESCRIPTION
Travis integration is untested, but should work.  AFAIK, the only way to really test that it works is to commit it and then it will test any commits afterward.  Whoever lands this will need to create/locate the correct user in sonar and replace the `secure:` entries in `.travis.yml` accordingly

badges show current version and build status.

FWIW, right now I believe `master` is broken.
