### PR TITLE
clear iterator id between enumerations

### DIFF
--- a/lib/sonar/request.rb
+++ b/lib/sonar/request.rb
@@ -58,6 +58,7 @@ module Sonar
           more = resp['more']
           yield resp
         end
+        params.delete(:iterator_id)
       end
     end
   end


### PR DESCRIPTION
when calling #each on the Requestiterator
the iterator_id needs to be cleared at the end
so that #each can be called again from the begining
without failing
