### PR TITLE
Update sonar CLI to exit non-zero when errors are encountered

### DIFF
--- a/bin/sonar
+++ b/bin/sonar
@@ -5,7 +5,7 @@ require 'bundler/setup'
 require 'sonar'
 
 begin
-  Sonar::CLI.start(ARGV)
+  exit(Sonar::CLI.start(ARGV))
 rescue Interrupt
   puts 'Quitting...'
 end

--- a/lib/sonar/cli/cli.rb
+++ b/lib/sonar/cli/cli.rb
@@ -35,13 +35,18 @@ module Sonar
       @query[:exact] = options['exact']
       resp = @client.search(@query)
 
+      errors = 0
       if resp.is_a?(Sonar::Request::RequestIterator)
         resp.each do |data|
+          errors += 1 if data.key?('errors') || data.key?('error')
           print_json(cleanup_data(data), options['format'])
         end
       else
+        errors += 1 if resp.key?('errors') || resp.key?('error')
         print_json(cleanup_data(resp), options['format'])
       end
+
+      return errors
     end
 
     desc 'types', 'List all Sonar query types'


### PR DESCRIPTION
I am very lazy and even though the output clearly says error/errors, itis easily overlooked and makes using this with standard UNIX tools and command line stuff is harder when it doesn't exit this way:

```
WARNING: Could not parse the response into lines, there was no collection.
{"error":"Invalid query","errors":["Expected a domain but got '1'"]}
0
$  ./bin/sonar search fdns 1 --format lines ; echo $?
WARNING: Could not parse the response into lines, there was no collection.
{"error":"Invalid query","errors":["Expected a domain but got '1'"]}
1
```

I updated the specs while here.
