### PR TITLE
Fix #13: Correct handling of errors when searching

### DIFF
--- a/bin/sonar
+++ b/bin/sonar
@@ -5,7 +5,9 @@ require 'bundler/setup'
 require 'sonar'
 
 begin
-  exit(Sonar::CLI.start(ARGV))
+  Sonar::CLI.start(ARGV)
+rescue Sonar::Search::SearchError => e
+  exit 1
 rescue Interrupt
   puts 'Quitting...'
 end

--- a/lib/sonar/cli/cli.rb
+++ b/lib/sonar/cli/cli.rb
@@ -46,7 +46,7 @@ module Sonar
         print_json(cleanup_data(resp), options['format'])
       end
 
-      return errors
+      raise Search::SearchError.new("Encountered #{errors} errors while searching") if errors > 0
     end
 
     desc 'types', 'List all Sonar query types'

--- a/lib/sonar/search.rb
+++ b/lib/sonar/search.rb
@@ -19,6 +19,12 @@ module Sonar
     }
 
     ##
+    # Generic exception for errors encountered while searching
+    ##
+    class SearchError < StandardError
+    end
+
+    ##
     # Get search
     #
     # params take in search type as key and query as value


### PR DESCRIPTION
Fixes #13:

```
$  for f in config help profile types usage; do                                                                                                              
./bin/sonar $f; echo $?
done
Your config file is located at /Users/jhart/sonar.rc
0
Commands:
  sonar config                            # Sonar config file location
  sonar help [COMMAND]                    # Describe available commands or one specific command
  sonar profile                           # Display the current profile from sonar.rc
  sonar search [QUERY TYPE] [QUERY TERM]  # Search anything from Sonars
  sonar types                             # List all Sonar query types
  sonar usage                             # Display API usage for current user

Options:
  [--format=FORMAT]  # Flat JSON, JSON lines, or pretty printed [flat/lines/pretty]

0
{
           "email" => "jon_hart@rapid7.com",
    "access_token" => "<redacted>",
         "api_url" => "https://sonar.labs.rapid7.com",
          "format" => "flat",
    "record_limit" => 10000
}
0
{
    "certificate" => "Certificate lookup",
        "certips" => "Certificate to IPs",
           "rdns" => "IP to Reverse DNS Lookup or DNS Lookup to IP",
           "fdns" => "Domains to IP or IPs to Domain",
        "ipcerts" => "IP to Certificates",
      "namecerts" => "Domain to Certificates",
       "links_to" => "HTTP References to Domain",
          "ports" => "Open Ports",
      "processed" => "Open Ports (Processed)",
            "raw" => "Open Ports (Raw)",
        "sslcert" => "Certificate Details",
       "whois_ip" => "Whois (IP)"
}
0
{
                "user" => {
                   "name" => "Jon Hart",
                  "email" => "jon_hart@rapid7.com",
              "api_token" => "<redacted>",
        "api_daily_limit" => 99999999
    },
    "current_api_hits" => 141
}
0
```

```
$  ./bin/sonar search rdns 8.8.8.8; echo $?
{"collection":[{"address":"8.8.8.8","name":"google-public-dns-a.google.com","sources":["20160127","20160210","20160217","20160224","20160302","20160309","20160316","20160323","20160330","20160406","20160413"]}],"more":false,"warning":"","iterator_id":"8a1152f1d1e9e677"}
0
$  ./bin/sonar search rdns blah; echo $?   
{"error":"Invalid query","errors":["Expected a domain but got 'blah'"]}
1
```

While here I also corrected the unit tests which were just exacerbating the problem. 
