### PR TITLE
Create basic search_all command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.2.0
+  - 2.2.2
   - jruby
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.1.5
+  - 2.2.0
   - jruby
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"

--- a/lib/sonar/cli/cli.rb
+++ b/lib/sonar/cli/cli.rb
@@ -4,6 +4,7 @@ require 'thor'
 require 'sonar/cli/rcfile'
 require 'sonar/search'
 require 'awesome_print'
+require 'table_print'
 
 include Sonar::Search
 
@@ -53,7 +54,8 @@ module Sonar
 
     desc 'types', 'List all Sonar query types'
     def types
-      ap QUERY_TYPES
+      tp.set :io, $stdout
+      tp QUERY_TYPES, :name, { description: { width: 100 } }, :input
     end
 
     desc 'config', 'Sonar config file location'

--- a/lib/sonar/cli/cli.rb
+++ b/lib/sonar/cli/cli.rb
@@ -65,7 +65,7 @@ module Sonar
 
     desc 'types', 'List all Sonar query types'
     def types
-      ap Search::QUERY_TYPES_MAP
+      ap QUERY_TYPES
     end
 
     desc 'config', 'Sonar config file location'

--- a/lib/sonar/cli/cli.rb
+++ b/lib/sonar/cli/cli.rb
@@ -5,6 +5,8 @@ require 'sonar/cli/rcfile'
 require 'sonar/search'
 require 'awesome_print'
 
+include Sonar::Search
+
 module Sonar
   class CLI < Thor
     class_option 'format', type: :string, desc: 'Flat JSON, JSON lines, or pretty printed [flat/lines/pretty]'
@@ -27,7 +29,12 @@ module Sonar
 
     desc 'search_all [QUERY TERM]', 'Search all Sonar record types'
     def search_all(term)
-      Sonar::Search::QUERY_TYPES_MAP.keys.each do |type|
+      if term =~ IS_IP
+        types = ip_search_type_names
+      else
+        types = domain_search_type_names
+      end
+      types.each do |type|
         search(type, term) rescue 'Search failed'
       end
     end

--- a/lib/sonar/cli/cli.rb
+++ b/lib/sonar/cli/cli.rb
@@ -10,7 +10,7 @@ include Sonar::Search
 
 module Sonar
   class CLI < Thor
-    class_option 'format', type: :string, desc: 'Flat JSON, JSON lines, or pretty printed [flat/lines/pretty]'
+    class_option 'format', type: :string, desc: 'Flat JSON (include empty collections), JSON lines of collection data (default), or pretty printed [flat/lines/pretty]'
 
     def initialize(*)
       @config = Sonar::RCFile.instance.load_file

--- a/lib/sonar/search.rb
+++ b/lib/sonar/search.rb
@@ -48,6 +48,21 @@ module Sonar
       QUERY_TYPES.map { |type| type[:name] }
     end
 
+    def handle_search_response(resp)
+      errors = 0
+      if resp.is_a?(Sonar::Request::RequestIterator)
+        resp.each do |data|
+          errors += 1 if data.key?('errors') || data.key?('error')
+          print_json(cleanup_data(data), options['format'])
+        end
+      else
+        errors += 1 if resp.key?('errors') || resp.key?('error')
+        print_json(cleanup_data(resp), options['format'])
+      end
+
+      raise Search::SearchError.new("Encountered #{errors} errors while searching") if errors > 0
+    end
+
     ##
     # Get search
     #

--- a/lib/sonar/search.rb
+++ b/lib/sonar/search.rb
@@ -18,7 +18,8 @@ module Sonar
       { name: 'ports', description: 'Open Ports', input: 'ip' },
       { name: 'processed', description: 'Open Ports (Processed)', input: 'ip' },
       { name: 'raw', description: 'Open Ports (Raw)', input: 'ip' },
-      { name: 'sslcert', description: 'Certificate Details', input: 'sha' }
+      { name: 'sslcert', description: 'Certificate Details', input: 'sha' },
+      { name: 'all', description: 'Search all appropriate search types for an IP or domain', input: 'all' }
     ]
 
     ##

--- a/lib/sonar/search.rb
+++ b/lib/sonar/search.rb
@@ -2,26 +2,50 @@
 
 module Sonar
   module Search
+
+    # Allow IP queries to be in the form of "1.", "1.2.", "1.2.3.", and "1.2.3.4"
+    IS_IP = /^(\d{1,3}\.|\d{1,3}\.\d{1,3}\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/
+
     # Implemented search query types
-    QUERY_TYPES_MAP = {
-      'certificate' => 'Certificate lookup',
-      'certips'     => 'Certificate to IPs',
-      'rdns'        => 'IP to Reverse DNS Lookup or DNS Lookup to IP',
-      'fdns'        => 'Domains to IP or IPs to Domain',
-      'ipcerts'     => 'IP to Certificates',
-      'namecerts'   => 'Domain to Certificates',
-      'links_to'    => 'HTTP References to Domain',
-      'ports'       => 'Open Ports',
-      'processed'   => 'Open Ports (Processed)',
-      'raw'         => 'Open Ports (Raw)',
-      'sslcert'     => 'Certificate Details',
-      'whois_ip'    => 'Whois (IP)'
-    }
+    QUERY_TYPES = [
+      { name: 'certificate', description: 'Certificate lookup', input: 'sha' },
+      { name: 'certips', description: 'Certificate to IPs', input: 'sha' },
+      { name: 'rdns', description: 'IP to Reverse DNS Lookup or DNS Lookup to IP', input: 'ip' },
+      { name: 'fdns', description: 'Domains to IP or IPs to Domain', input: 'domain' },
+      { name: 'ipcerts', description: 'IP to Certificates', input: 'ip' },
+      { name: 'namecerts', description: 'Domain to Certificates', input: 'domain' },
+      { name: 'links_to', description: 'HTTP References to Domain', input: 'domain' },
+      { name: 'ports', description: 'Open Ports', input: 'ip' },
+      { name: 'processed', description: 'Open Ports (Processed)', input: 'ip' },
+      { name: 'raw', description: 'Open Ports (Raw)', input: 'ip' },
+      { name: 'sslcert', description: 'Certificate Details', input: 'sha' },
+      { name: 'whois_ip', description: 'Whois (IP)', input: 'ip' }
+    ]
 
     ##
     # Generic exception for errors encountered while searching
     ##
     class SearchError < StandardError
+    end
+
+    def ip_search_type_names
+      ip_search_types.map { |type| type[:name] }
+    end
+
+    def domain_search_type_names
+      domain_search_types.map { |type| type[:name] }
+    end
+
+    def ip_search_types
+      QUERY_TYPES.select { |type| type[:input] == 'ip' }
+    end
+
+    def domain_search_types
+      QUERY_TYPES.select { |type| type[:input] == 'domain' }
+    end
+
+    def query_type_names
+      QUERY_TYPES.map { |type| type[:name] }
     end
 
     ##
@@ -32,7 +56,7 @@ module Sonar
     #
     # @return [Hashie::Mash] with response of search
     def search(params = {})
-      type_query = params.select { |k, _v| QUERY_TYPES_MAP.keys.include?(k.to_s) }.first
+      type_query = params.select { |k, _v| query_type_names.include?(k.to_s) }.first
       fail ArgumentError, "The query type provided is invalid or not yet implemented." unless type_query
       type = type_query[0].to_sym
       params[:q] = type_query[1]

--- a/sonar-client.gemspec
+++ b/sonar-client.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json'
   spec.add_dependency 'thor'
   spec.add_dependency 'awesome_print'
+  spec.add_dependency 'table_print'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/spec/sonar/cli_spec.rb
+++ b/spec/sonar/cli_spec.rb
@@ -83,6 +83,13 @@ describe Sonar::CLI do
       end
     end
 
+    describe 'sonar types command' do
+      it 'returns all sonar search types' do
+        output = run_command('types')
+        expect(output).to match(/Certificate to IPs/)
+      end
+    end
+
     describe 'search_all command' do
       before do
         allow_any_instance_of(Sonar::Client).to receive(:search).and_return(

--- a/spec/sonar/cli_spec.rb
+++ b/spec/sonar/cli_spec.rb
@@ -82,6 +82,22 @@ describe Sonar::CLI do
         end
       end
     end
+
+    describe 'search_all command' do
+      before do
+        allow_any_instance_of(Sonar::Client).to receive(:search).and_return(
+          Sonar::Client.new.search(fdns: '208.118.227.20', exact: true)
+        )
+      end
+      it 'returns results when searching for an IP' do
+        output = run_command('search_all 208.118.227.20')
+        expect(output).to match(/rapid7\.com/)
+      end
+      it 'returns results when searching for a domain' do
+        output = run_command('search_all rapid7.com')
+        expect(output).to match(/208\.118\.227\.20/)
+      end
+    end
   end
 
   def run_command(args)

--- a/spec/sonar/cli_spec.rb
+++ b/spec/sonar/cli_spec.rb
@@ -90,18 +90,18 @@ describe Sonar::CLI do
       end
     end
 
-    describe 'search_all command' do
+    describe 'search all command' do
       before do
         allow_any_instance_of(Sonar::Client).to receive(:search).and_return(
           Sonar::Client.new.search(fdns: '208.118.227.20', exact: true)
         )
       end
       it 'returns results when searching for an IP' do
-        output = run_command('search_all 208.118.227.20')
+        output = run_command('search all 208.118.227.20')
         expect(output).to match(/rapid7\.com/)
       end
       it 'returns results when searching for a domain' do
-        output = run_command('search_all rapid7.com')
+        output = run_command('search all rapid7.com')
         expect(output).to match(/208\.118\.227\.20/)
       end
     end

--- a/spec/sonar/search_spec.rb
+++ b/spec/sonar/search_spec.rb
@@ -15,12 +15,12 @@ describe Sonar::Search do
 
     describe "exact" do
       it "shouldn't match anything when #exact is true" do
-        resp = client.search(rdns: "1.1.", exact: true)
+        resp = client.search(fdns: ".rapid7.com", exact: true)
         expect(resp["collection"].size).to eq(0)
       end
       it "should match when #exact is false" do
-        resp = client.search(rdns: "1.1.", exact: false)
-        expect(resp["collection"].first["address"]).to match(/^1.1./)
+        resp = client.search(fdns: ".rapid7.com", exact: false)
+        expect(resp["collection"].size).to be > 0 
       end
     end
 

--- a/spec/sonar/search_spec.rb
+++ b/spec/sonar/search_spec.rb
@@ -4,6 +4,24 @@ require 'spec_helper'
 describe Sonar::Search do
   let(:client) { Sonar::Client.new }
 
+  describe "#ip_search_type_names" do
+    it 'includes rdns' do
+      expect(subject.ip_search_type_names).to include('rdns')
+    end
+    it 'does not include fdns' do
+      expect(subject.ip_search_type_names).to_not include('fdns')
+    end
+  end
+
+  describe "#domain_search_type_names" do
+    it 'includes fdns' do
+      expect(subject.domain_search_type_names).to include('fdns')
+    end
+    it 'does not include rdns' do
+      expect(subject.domain_search_type_names).to_not include('rdns')
+    end
+  end
+
   describe "parameters" do
     describe "query type" do
       context "with an invalid query type" do


### PR DESCRIPTION
Searches all record types, regardless of input.  Perhaps it should determine the kind of input (IP, domain, SHA, etc.) and filter which record types it queries?  
