### PR TITLE
Remove whois support

### DIFF
--- a/lib/sonar/search.rb
+++ b/lib/sonar/search.rb
@@ -15,7 +15,6 @@ module Sonar
       'processed'   => 'Open Ports (Processed)',
       'raw'         => 'Open Ports (Raw)',
       'sslcert'     => 'Certificate Details',
-      'whois_ip'    => 'Whois (IP)'
     }
 
     ##

--- a/spec/sonar/search_spec.rb
+++ b/spec/sonar/search_spec.rb
@@ -152,14 +152,6 @@ describe Sonar::Search do
     end
   end
 
-  context "whois_ip" do
-    let(:resp) { client.search(whois_ip: '208.118.227.10') }
-
-    xit "should find rapid7.com" do
-      expect(resp['name']).to eq('TWDX-208-118-227-0-1')
-    end
-  end
-
   # TODO: actually check response
   context "raw" do
     let(:resp) { client.search(raw: '208.118.227.10') }


### PR DESCRIPTION
Otherwise is just returns errors:

```
$  ./bin/sonar search whois_ip f
{"error":"Data not found","errors":["whois data is no longer collected"]}
[ jhart@LAX-MBP-1576 (08/09/17 15:10:06) ~/rapid7/sonar-client  <err: 1> ]                                                                                                                                                                                              
```

After:

```       
$  ./bin/sonar types
{
    "certificate" => "Certificate lookup",
        "certips" => "Certificate to IPs",
           "rdns" => "IP to Reverse DNS Lookup or DNS Lookup to IP",
           "fdns" => "Domains to IP or IPs to Domain",
        "ipcerts" => "IP to Certificates",
      "namecerts" => "Domain to Certificates",
       "links_to" => "HTTP References to Domain",
          "ports" => "Open Ports",
      "processed" => "Open Ports (Processed)",
            "raw" => "Open Ports (Raw)",
        "sslcert" => "Certificate Details"
}
```