### PR TITLE
Update tests to accept >= 2 IPs for rapid7 rather than specific IPs

### DIFF
--- a/spec/sonar/search_spec.rb
+++ b/spec/sonar/search_spec.rb
@@ -107,8 +107,8 @@ describe Sonar::Search do
       it "returns hashie response of search" do
         expect(resp.class).to eq(Hashie::Mash)
       end
-      it "finds fdnsname 13.32.205.* IP addresses for rapid7.com" do
-        expect(resp['collection'].select { |x| x['address'].match(/^13\.32\.205\.\d{1,3}$/) }.size).to be >= 2
+      it "finds fdnsname multiple IP addresses for rapid7.com" do
+        expect(resp['collection'].select { |x| x['address'] }.size).to be >= 2
       end
     end
 


### PR DESCRIPTION
This is intended to fix:

```
  1) Sonar::Search fdns fdnsname finds fdnsname 13.32.205.* IP addresses for rapid7.com
     Failure/Error: expect(resp['collection'].select { |x| x['address'].match(/^13\.32\.205\.\d{1,3}$/) }.size).to be >= 2
       expected: >= 2
            got:    0
     # ./spec/sonar/search_spec.rb:111:in `block (4 levels) in <top (required)>'
Finished in 20.01 seconds (files took 0.54407 seconds to load)
```

(https://travis-ci.org/rapid7/sonar-client/jobs/464520837)