### PR TITLE
SNR-993: Update spec to new domain because of IP change

### DIFF
--- a/spec/sonar/search_spec.rb
+++ b/spec/sonar/search_spec.rb
@@ -115,8 +115,8 @@ describe Sonar::Search do
     context "fdnsip" do
       let(:resp) { client.search(fdns: '208.118.227.10') }
 
-      it "finds fdnsip rapid7.com at 208.118.227.10" do
-        expect(resp['collection'].any? { |x| x['address'].match('rapid7') }).to be(true)
+      it "finds fdnsip rapid7 domains at 208.118.227.10" do
+        expect(resp['collection'].any? { |x| x['address'].match('rapidseven') }).to be(true)
       end
     end
 


### PR DESCRIPTION
Our rapid7.com IP address changed so this PR updates the specs to look for a different domain. 