### PR TITLE
SNR-1078: Bump ruby versions tested in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ cache: bundler
 rvm:
   - '2.3.0'
   - '2.4.5'
-  - '2.5.3'
-  - '2.6.1'
+  - '2.5.5'
+  - '2.6.5'
   - 'jruby-head'
 before_install:
   - gem install bundler


### PR DESCRIPTION
ruby-2.5.3 was failing in Travis likely due to some issues with old version support.  I bumped some of the ruby versions around to more stable releases that clients would likely use. 